### PR TITLE
Typo: Fix github issues url in footer

### DIFF
--- a/themes/webdriver.io/layout/_partial/footer.ejs
+++ b/themes/webdriver.io/layout/_partial/footer.ejs
@@ -14,7 +14,7 @@
             <p>
                 If you have questions or any problems using WebdriverIO join the
                 <a href="https://groups.google.com/forum/#!forum/webdriverio">Mailing List</a>, hit us
-                contributor on Twitter or just file an <a href="https://github.com/camme/webdriverio/issues">issue</a>
+                contributor on Twitter or just file an <a href="https://github.com/webdriverio/webdriverio/issues">issue</a>
                 on Github. We will try to get back to you as soon as possible.<br>
                 Also if you miss any feature, let us know so we can make WebdriverIO
                 even better. For news or announcements check <a href="https://twitter.com/WebdriverIO">@WebdriverIO</a> on Twitter.


### PR DESCRIPTION
was still referencing old url.
