### PR TITLE
Bump Selenium version

### DIFF
--- a/source/guide.md
+++ b/source/guide.md
@@ -23,14 +23,14 @@ Then let's download the current [selenium standalone server](http://docs.seleniu
 
 ** 2. Download selenium standalone server**
 ```sh
-$ curl -O http://selenium-release.storage.googleapis.com/2.42/selenium-server-standalone-2.42.2.jar
+$ curl -O http://selenium-release.storage.googleapis.com/2.42/selenium-server-standalone-2.43.1.jar
 ```
 
 Start the server by executing the following:
 
 ** 3. Start selenium standalone server**
 ```sh
-$ java -jar selenium-server-standalone-2.42.2.jar
+$ java -jar selenium-server-standalone-2.43.1.jar
 ```
 
 Keep this running in the background and open a new terminal window. Next step is to download WebdriverIO via


### PR DESCRIPTION
Firefox 32 doesn't work with Webdriver 2.42 (at least on OSX Yosemite and maybe Mavericks): [#7810](https://code.google.com/p/selenium/issues/detail?id=7810) [#7823](https://code.google.com/p/selenium/issues/detail?id=7823).

Bumping to 2.43.1 fixed it, so the docs should maybe be updated.
