### PR TITLE
Quick link to github repo via the navbar

### DIFF
--- a/themes/webdriver.io/layout/_partial/navi.ejs
+++ b/themes/webdriver.io/layout/_partial/navi.ejs
@@ -6,6 +6,9 @@
         <li><a href="/guide.html">Developer Guide</a></li>
         <li><a href="/api.html">API</a></li>
         <li><a href="/contribute.html">Contribute</a></li>
+        <li style="float: right">
+        	<a href="https://github.com/webdriverio/webdriverio/" target="_blank">Github</a>
+        </li>
     </ul>
 </nav>
 <% }); %>


### PR DESCRIPTION
I find myself looking at the github repo often, and this pull request adds a quick link to the github repo to the navbar of the website.
