### PR TITLE
revert hexo-server version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "hexo-renderer-ejs": "^0.2.0",
     "hexo-renderer-marked": "^0.2.11",
     "hexo-renderer-stylus": "^0.3.1",
-    "hexo-server": "^0.2.2",
+    "hexo-server": "^0.2.0",
     "hexo-wdio-generator": "~0.1.5"
   },
   "hexo": {


### PR DESCRIPTION
Was receiving the following error when running `npm install` on a clean clone:
```
npm ERR! node v6.5.0
npm ERR! npm  v3.10.7

npm ERR! No compatible version found: hexo-server@^0.2.2
npm ERR! Valid install targets:
npm ERR! 0.2.0, 0.1.3, 0.1.2, 0.1.1, 0.1.0, 0.0.4, 0.0.3, 0.0.2, 0.0.1
```
Looking at [the hexo-server release page](https://github.com/hexojs/hexo-server/releases), seems 0.2 is their latest. 