### PR TITLE
Add anchor link links to headings

### DIFF
--- a/themes/webdriver.io/source/css/_components/_headings.scss
+++ b/themes/webdriver.io/source/css/_components/_headings.scss
@@ -53,3 +53,26 @@ h6 {
     padding: 10px 0 0;
     font-weight: bold;
 }
+
+.doc {
+    h2, h3, h4, h5, h6 {
+        position: relative;
+
+        .headerlink {
+            display: none;
+            position: absolute;
+            right: 100%;
+            padding: 1px 3px;
+            font-size: .8em;
+            text-decoration: none;
+
+            &::before {
+                content: '#';
+            }
+        }
+
+        &:hover .headerlink {
+            display: inline;
+        }
+    }
+}


### PR DESCRIPTION
I've found myself linking to specific headings on the page and figure this would help make it easier. Testing in FF and Chrome on my macbook.

Example:
![link](https://cloud.githubusercontent.com/assets/706039/21536998/248da9b2-cd50-11e6-9c97-1c33b7019d1e.gif)
