### PR TITLE
Updated status badges from png to svg

### DIFF
--- a/themes/webdriver.io/layout/start.ejs
+++ b/themes/webdriver.io/layout/start.ejs
@@ -3,9 +3,9 @@
     <h1 class="header">Webdriver<span>I/O</span></h1>
     <h2>Selenium 2.0 bindings for NodeJS</h2>
     <div class="badges">
-        <a href="http://badge.fury.io/js/webdriverio" data-bindattr-34="34"><img src="https://badge.fury.io/js/webdriverio.png" data-bindattr-35="35" class="retina-badge"></a>
+        <a href="http://badge.fury.io/js/webdriverio" data-bindattr-34="34"><img src="https://badge.fury.io/js/webdriverio.svg" data-bindattr-35="35" class="retina-badge"></a>
         <a href="https://travis-ci.org/webdriverio/webdriverio"><img src="https://travis-ci.org/webdriverio/webdriverio.svg" alt="Build Status"></a>
-        <a href="https://coveralls.io/r/webdriverio/webdriverio?branch=master"><img src="https://camo.githubusercontent.com/9216ad89ebf7693bc4c8e3b7e85d841b314a8e59/68747470733a2f2f636f766572616c6c732e696f2f7265706f732f63616d6d652f7765626472697665726a732f62616467652e706e673f6272616e63683d6d617374657226" alt="Coverage Status" data-canonical-src="https://coveralls.io/repos/webdriverio/webdriverio/badge.png?branch=master&amp;" style="max-width:100%;"></a>
+        <a href="https://coveralls.io/r/webdriverio/webdriverio?branch=master"><img src="https://coveralls.io/repos/github/webdriverio/webdriverio/badge.svg?branch=master" alt="Coverage Status"></a>
     </div>
     <div>
         <div class="fb-like" data-send="false" data-width="50" data-show-faces="false" data-font="arial" data-layout="button_count" data-action="like"></div>


### PR DESCRIPTION
I've updated the status badges on the homepage from png -> svg. Also the coverage badge was pointing toward the github cached image `camo.githubusercontent.com` rather than `coveralls.io` which is also fixed.

Before:
<img width="292" alt="screen shot 2017-02-20 at 15 59 35" src="https://cloud.githubusercontent.com/assets/235915/23132515/c2e0f984-f785-11e6-9e7b-e3f2f75ef3a2.png">

After:
<img width="325" alt="screen shot 2017-02-20 at 15 50 36" src="https://cloud.githubusercontent.com/assets/235915/23132521/c4883022-f785-11e6-8199-7a11b9f5fcd7.png">
